### PR TITLE
Support for hex RGB codes

### DIFF
--- a/1_21_2/assets/minecraft/shaders/include/text_effects_utils.glsl
+++ b/1_21_2/assets/minecraft/shaders/include/text_effects_utils.glsl
@@ -40,9 +40,17 @@ bool checkAndSetShadow(ivec3 c, int R, int G, int B) {
 #define TEXT_EFFECT(R, G, B) \
     if (c.r == R && c.g == G && c.b == B)
 
+// TEXT_EFFECT_HEX macro: matches RGB color only (exact match)
+#define TEXT_EFFECT_HEX(RGB) \
+    TEXT_EFFECT((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
+
 // TEXT_EFFECT_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
 #define TEXT_EFFECT_WITH_SHADOW(R, G, B) \
     if (checkAndSetShadow(c, R, G, B))
+
+// TEXT_EFFECT_HEX_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
+#define TEXT_EFFECT_HEX_WITH_SHADOW(RGB) \
+    TEXT_EFFECT_WITH_SHADOW((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
 
 void applyTextEffects() {
     vec4 vertex = vec4(Position, 1.0);

--- a/1_21_6/assets/minecraft/shaders/include/text_effects_utils.glsl
+++ b/1_21_6/assets/minecraft/shaders/include/text_effects_utils.glsl
@@ -40,9 +40,17 @@ bool checkAndSetShadow(ivec3 c, int R, int G, int B) {
 #define TEXT_EFFECT(R, G, B) \
     if (c.r == R && c.g == G && c.b == B)
 
+// TEXT_EFFECT_HEX macro: matches RGB color only (exact match)
+#define TEXT_EFFECT_HEX(RGB) \
+    TEXT_EFFECT((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
+
 // TEXT_EFFECT_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
 #define TEXT_EFFECT_WITH_SHADOW(R, G, B) \
     if (checkAndSetShadow(c, R, G, B))
+
+// TEXT_EFFECT_HEX_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
+#define TEXT_EFFECT_HEX_WITH_SHADOW(RGB) \
+    TEXT_EFFECT_WITH_SHADOW((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
 
 void applyTextEffects() {
     vec4 vertex = vec4(Position, 1.0);

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -10,6 +10,21 @@ TEXT_EFFECT(R, G, B) {
 }
 ```
 
+### Hex Support
+
+You can use hex codes to with the color helpers or the TEXT\_EFFECT\_HEX macro
+
+```glsl
+TEXT_EFFECT_HEX(0xF8F876) {
+    apply_shake();
+}
+
+TEXT_EFFECT_HEX_WITH_SHADOW(0xF9F913) {
+    apply_wavy();
+    apply_color(rgb(0xFF0000));
+}
+```
+
 ### Shadow Support
 
 > [!WARNING]
@@ -73,14 +88,18 @@ This is useful when you want to use a specific trigger color but display the tex
 
 ### Color Helpers
 
-Two helper functions construct color vectors from 0–255 integer components:
+Four helper functions construct color vectors from integer components:
 
 - `rgb(R, G, B)` → `vec3` with components in 0..1
 - `rgba(R, G, B, A)` → `vec4`, where `A` is alpha in 0.0..1.0
+- `rgb(RGB)` → `vec3` with components in 0..1
+- `rgba(RGBA)` → `vec4` with components in 0..1
 
 ```glsl
 apply_color(rgb(255, 80, 80));            // opaque red
+apply_color(rgb(0x50FF50));               // opaque green
 apply_color(rgba(255, 80, 80, 0.5));      // 50 % transparent red
+apply_color(rgba(0x50FF5080));            // 50 % transparent green
 apply_gradient(rgba(255, 0, 0, 1.0),
                rgba(0, 0, 255, 0.0), 2.0); // fade-out gradient
 ```

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,7 +65,7 @@ Use `apply_color()` to display a different color than the trigger color:
 // Display color: white (255, 255, 255)
 TEXT_EFFECT(200, 100, 50) {
     apply_shake();
-    apply_color(255, 255, 255);
+    apply_color(rgb(255, 255, 255));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,33 +26,33 @@ Yes, provided that you keep the [license file](./LICENSE) within the resource pa
 
 | Effect                                                                                                                               | Description               |
 | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
-| [`apply_shake(speed, intensity)`](./CONFIGURATION.md#apply_shakefloat-speed-float-intensity)                                                           | Random shaking            |
-| [`apply_wavy(speed, amplitude, xFrequency)`](./CONFIGURATION.md#apply_wavyfloat-speed-float-amplitude-float-xfrequency)                                | Wave animation            |
-| [`apply_rainbow(speed)`](./CONFIGURATION.md#apply_rainbowfloat-speed)                                                                                  | Rainbow color cycle       |
-| [`apply_bouncy(speed, amplitude)`](./CONFIGURATION.md#apply_bouncyfloat-speed-float-amplitude)                                                         | Bounce animation          |
-| [`apply_blinking(speed)`](./CONFIGURATION.md#apply_blinkingfloat-speed)                                                                                | Blink on/off              |
-| [`apply_pulse(speed, size)`](./CONFIGURATION.md#apply_pulsefloat-speed-float-size)                                                                     | Grow/Shrink animation     |
-| [`apply_spin(speed)`](./CONFIGURATION.md#apply_spinfloat-speed)                                                                                        | Rotation                  |
-| [`apply_sequential_spin(speed)`](./CONFIGURATION.md#apply_sequential_spinfloat-speed)                                                                  | Sequential character spin |
-| [`apply_fade(speed)`](./CONFIGURATION.md#apply_fadefloat-speed)                                                                                        | Fade in/out               |
-| [`apply_iterating(speed, space)`](./CONFIGURATION.md#apply_iteratingfloat-speed-float-space)                                                           | Sequential jump           |
-| [`apply_glitch(speed, intensity)`](./CONFIGURATION.md#apply_glitchfloat-speed-float-intensity)                                                         | Random displacement       |
-| [`apply_scale(scale, offsetX, offsetY)`](./CONFIGURATION.md#apply_scalefloat-scale-float-offsetx-float-offsety)                                        | Scale text                |
-| [`apply_offset(offsetX, offsetY)`](./CONFIGURATION.md#apply_offsetfloat-offsetx-float-offsety)                                                         | Move text position        |
-| [`apply_gradient(startColor, endColor, direction)`](./CONFIGURATION.md#apply_gradient)                    | Static linear gradient    |
-| [`apply_dynamic_gradient(start, end, dir, speed)`](./CONFIGURATION.md#apply_dynamic_gradient) | Animated moving gradient  |
-| [`apply_lava(speed)`](./CONFIGURATION.md#apply_lavafloat-speed)                                                                                        | Flowing lava effect       |
-| [`apply_color(color)`](./CONFIGURATION.md#apply_color)                                                                                                  | Override display color    |
-| [`apply_aurora(c1, c2, c3, speed)`](./CONFIGURATION.md#apply_aurora)                                                                                   | Flowing 3-color aurora    |
-| [`apply_split(intensity, speed)`](./CONFIGURATION.md#apply_split)                                                                                       | Animated horizontal split |
-| [`apply_outline(color, thickness)`](./CONFIGURATION.md#apply_outline)                                                                                  | Glyph outline (fragment)  |
-| [`apply_hatch(color, speed, density)`](./CONFIGURATION.md#apply_hatch)                                                                                 | Diagonal hatching (frag)  |
-| [`apply_neon(color, intensity, speed)`](./CONFIGURATION.md#apply_neon)                                                                                  | Neon glow (fragment)      |
-| [`apply_chromatic(intensity, speed)`](./CONFIGURATION.md#apply_chromatic)                                                                              | Chromatic aberration frag |
-| [`apply_extrude(depth, layers)`](./CONFIGURATION.md#apply_extrude)                                                                                     | 3D depth shadow (frag)    |
-| [`apply_noise(intensity, speed)`](./CONFIGURATION.md#apply_noise)                                                                                      | Noise / static (fragment) |
-| [`apply_liquid(intensity, speed)`](./CONFIGURATION.md#apply_liquid)                                                                                    | Liquid morph (fragment)   |
-| [`apply_water(color, level, amp, speed)`](./CONFIGURATION.md#apply_water)                                                                              | Wavy water-fill animation |
+| [`apply_shake(speed, intensity)`](./CONFIGURATION.md#apply_shakefloat-speed-float-intensity)                                         | Random shaking            |
+| [`apply_wavy(speed, amplitude, xFrequency)`](./CONFIGURATION.md#apply_wavyfloat-speed-float-amplitude-float-xfrequency)              | Wave animation            |
+| [`apply_rainbow(speed)`](./CONFIGURATION.md#apply_rainbowfloat-speed)                                                                | Rainbow color cycle       |
+| [`apply_bouncy(speed, amplitude)`](./CONFIGURATION.md#apply_bouncyfloat-speed-float-amplitude)                                       | Bounce animation          |
+| [`apply_blinking(speed)`](./CONFIGURATION.md#apply_blinkingfloat-speed)                                                              | Blink on/off              |
+| [`apply_pulse(speed, size)`](./CONFIGURATION.md#apply_pulsefloat-speed-float-size)                                                   | Grow/Shrink animation     |
+| [`apply_spin(speed)`](./CONFIGURATION.md#apply_spinfloat-speed)                                                                      | Rotation                  |
+| [`apply_sequential_spin(speed)`](./CONFIGURATION.md#apply_sequential_spinfloat-speed)                                                | Sequential character spin |
+| [`apply_fade(speed)`](./CONFIGURATION.md#apply_fadefloat-speed)                                                                      | Fade in/out               |
+| [`apply_iterating(speed, space)`](./CONFIGURATION.md#apply_iteratingfloat-speed-float-space)                                         | Sequential jump           |
+| [`apply_glitch(speed, intensity)`](./CONFIGURATION.md#apply_glitchfloat-speed-float-intensity)                                       | Random displacement       |
+| [`apply_scale(scale, offsetX, offsetY)`](./CONFIGURATION.md#apply_scalefloat-scale-float-offsetx-float-offsety)                      | Scale text                |
+| [`apply_offset(offsetX, offsetY)`](./CONFIGURATION.md#apply_offsetfloat-offsetx-float-offsety)                                       | Move text position        |
+| [`apply_gradient(startColor, endColor, direction)`](./CONFIGURATION.md#apply_gradient)                                               | Static linear gradient    |
+| [`apply_dynamic_gradient(start, end, dir, speed)`](./CONFIGURATION.md#apply_dynamic_gradient)                                        | Animated moving gradient  |
+| [`apply_lava(speed)`](./CONFIGURATION.md#apply_lavafloat-speed)                                                                      | Flowing lava effect       |
+| [`apply_color(color)`](./CONFIGURATION.md#apply_color)                                                                               | Override display color    |
+| [`apply_aurora(c1, c2, c3, speed)`](./CONFIGURATION.md#apply_aurora)                                                                 | Flowing 3-color aurora    |
+| [`apply_split(intensity, speed)`](./CONFIGURATION.md#apply_split)                                                                    | Animated horizontal split |
+| [`apply_outline(color, thickness)`](./CONFIGURATION.md#apply_outline)                                                                | Glyph outline (fragment)  |
+| [`apply_hatch(color, speed, density)`](./CONFIGURATION.md#apply_hatch)                                                               | Diagonal hatching (frag)  |
+| [`apply_neon(color, intensity, speed)`](./CONFIGURATION.md#apply_neon)                                                               | Neon glow (fragment)      |
+| [`apply_chromatic(intensity, speed)`](./CONFIGURATION.md#apply_chromatic)                                                            | Chromatic aberration frag |
+| [`apply_extrude(depth, layers)`](./CONFIGURATION.md#apply_extrude)                                                                   | 3D depth shadow (frag)    |
+| [`apply_noise(intensity, speed)`](./CONFIGURATION.md#apply_noise)                                                                    | Noise / static (fragment) |
+| [`apply_liquid(intensity, speed)`](./CONFIGURATION.md#apply_liquid)                                                                  | Liquid morph (fragment)   |
+| [`apply_water(color, level, amp, speed)`](./CONFIGURATION.md#apply_water)                                                            | Wavy water-fill animation |
 
 ---
 

--- a/assets/minecraft/shaders/include/_config.glsl
+++ b/assets/minecraft/shaders/include/_config.glsl
@@ -12,13 +12,13 @@ TEXT_EFFECT_WITH_SHADOW(248, 248, 84) {
 }
 
 // Wavy (#F8F858) - Green
-TEXT_EFFECT_WITH_SHADOW(248, 248, 88) {
+TEXT_EFFECT_HEX_WITH_SHADOW(0xF8F858) {
     apply_wavy();
     apply_color(rgb(80, 255, 80));
 }
 
 // Rainbow (#F8F85C)
-TEXT_EFFECT(248, 248, 92) {
+TEXT_EFFECT_HEX(0xF8F85C) {
     apply_rainbow();
 }
 

--- a/assets/minecraft/shaders/include/text_effects_api.glsl
+++ b/assets/minecraft/shaders/include/text_effects_api.glsl
@@ -120,8 +120,7 @@ void apply_color(vec3 color) {
 }
 
 void apply_color(vec4 color) {
-    currentBaseColor.rgb = color.rgb;
-    currentBaseColor.a = color.a;
+    currentBaseColor = color;
     flagColorOverride = true;
 }
 

--- a/assets/minecraft/shaders/include/text_effects_api.glsl
+++ b/assets/minecraft/shaders/include/text_effects_api.glsl
@@ -109,8 +109,24 @@ vec3 rgb(float r, float g, float b) {
     return vec3(r / 255.0, g / 255.0, b / 255.0);
 }
 
+// rgb from hex number
+vec3 rgb(int rgb_v) {
+    return vec3(float((rgb_v >> 16) & 0xFF) / 255.0, float((rgb_v >> 8) & 0xFF) / 255.0, float(rgb_v & 0xFF) / 255.0);
+}
+
+// rgba from 0-255 values and a decimal
 vec4 rgba(float r, float g, float b, float a) {
     return vec4(r / 255.0, g / 255.0, b / 255.0, a);
+}
+
+// rgba from hex number
+vec4 rgba(int rgba_v) {
+    float r = float(int(uint(rgba_v) >> uint(24)) & 0xFF) / 255.0;
+    float g = float((rgba_v >> 16) & 0xFF) / 255.0;
+    float b = float((rgba_v >> 8) & 0xFF) / 255.0;
+    float a = float(rgba_v & 0xFF) / 255.0;
+
+    return vec4(r, g, b, a);
 }
 
 // Set display color (different from trigger color)

--- a/assets/minecraft/shaders/include/text_effects_api.glsl
+++ b/assets/minecraft/shaders/include/text_effects_api.glsl
@@ -111,7 +111,10 @@ vec3 rgb(float r, float g, float b) {
 
 // rgb from hex number
 vec3 rgb(int rgb_v) {
-    return vec3(float((rgb_v >> 16) & 0xFF) / 255.0, float((rgb_v >> 8) & 0xFF) / 255.0, float(rgb_v & 0xFF) / 255.0);
+    float r = float((rgb_v >> 16) & 0xFF) / 255.0;
+    float g = float((rgb_v >> 8)  & 0xFF) / 255.0;
+    float b = float( rgb_v        & 0xFF) / 255.0;
+    return vec3(r, g, b);
 }
 
 // rgba from 0-255 values and a decimal
@@ -121,11 +124,26 @@ vec4 rgba(float r, float g, float b, float a) {
 
 // rgba from hex number
 vec4 rgba(int rgba_v) {
-    float r = float(int(uint(rgba_v) >> uint(24)) & 0xFF) / 255.0;
-    float g = float((rgba_v >> 16) & 0xFF) / 255.0;
-    float b = float((rgba_v >> 8) & 0xFF) / 255.0;
-    float a = float(rgba_v & 0xFF) / 255.0;
+    uint v = uint(rgba_v);
+    float r = float((v >> 24) & 0xFFu) / 255.0;
+    float g = float((v >> 16) & 0xFFu) / 255.0;
+    float b = float((v >> 8)  & 0xFFu) / 255.0;
+    float a = float( v        & 0xFFu) / 255.0;
+    return vec4(r, g, b, a);
+}
 
+// argb from 0-255 values and a decimal
+vec4 argb(float a, float r, float g, float b) {
+    return vec4(r / 255.0, g / 255.0, b / 255.0, a);
+}
+
+// argb from hex number
+vec4 argb(int argb_v) {
+    uint v = uint(argb_v);
+    float a = float((v >> 24) & 0xFFu) / 255.0;
+    float r = float((v >> 16) & 0xFFu) / 255.0;
+    float g = float((v >> 8)  & 0xFFu) / 255.0;
+    float b = float( v        & 0xFFu) / 255.0;
     return vec4(r, g, b, a);
 }
 

--- a/assets/minecraft/shaders/include/text_effects_utils.glsl
+++ b/assets/minecraft/shaders/include/text_effects_utils.glsl
@@ -40,9 +40,17 @@ bool checkAndSetShadow(ivec3 c, int R, int G, int B) {
 #define TEXT_EFFECT(R, G, B) \
     if (c.r == R && c.g == G && c.b == B)
 
+// TEXT_EFFECT_HEX macro: matches RGB color only (exact match)
+#define TEXT_EFFECT_HEX(RGB) \
+    TEXT_EFFECT((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
+
 // TEXT_EFFECT_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
 #define TEXT_EFFECT_WITH_SHADOW(R, G, B) \
     if (checkAndSetShadow(c, R, G, B))
+
+// TEXT_EFFECT_HEX_WITH_SHADOW macro: matches RGB color AND its shadow (exact match)
+#define TEXT_EFFECT_HEX_WITH_SHADOW(RGB) \
+    TEXT_EFFECT_WITH_SHADOW((RGB & 0xFF0000) >> 16, (RGB & 0x00FF00) >> 8, (RGB & 0x0000FF))
 
 void applyTextEffects() {
     vec4 vertex = vec4(Position, 1.0);


### PR DESCRIPTION
Adding support for hex codes in the rgb function and macros.  You can use `TEXT_EFFECT_HEX(0xFF0000)` to specify a hex code instead of rgb.

The rgb and rgba functions are also updated to take 0xRRGGBB and 0xRRGGBBAA respectively.

It's just meant to be a bit easier for people to configure their effects.